### PR TITLE
Fix the crash that occurs when the Add form is submitted with no data

### DIFF
--- a/src/components/Add.js
+++ b/src/components/Add.js
@@ -142,7 +142,7 @@ class AddForm extends React.Component {
       housingLevels: null,
       rightsLevels: null,
       birthYear: 0,
-      name: null,
+      name: "",
       gender: null,
       available: true,
       bio: null,


### PR DESCRIPTION
Trivial fix - the default state `name` just needs to be `""` rather than `null`.

Verified that this crash occurs without the fix, and does not occur with the fix (instead we get the expected "Invalid form" popup).

Fixes #23.