### PR TITLE
Support multiple app instances in AWS

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=http://localhost:8000/

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=https://juw492hzej.execute-api.eu-west-2.amazonaws.com/dev/

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_URL=https://juw492hzej.execute-api.eu-west-2.amazonaws.com/dev/
+REACT_APP_BACKEND_URL=https://j33aalkf3e.execute-api.eu-west-2.amazonaws.com/production/

--- a/src/cmn.js
+++ b/src/cmn.js
@@ -105,3 +105,10 @@ export function getExperienceForUrl(experience) {
 
   return experience_str;
 }
+
+/**
+ * Return a string containing the base URL of the API.
+ */
+export function getApiUrlBase() {
+  return process.env.REACT_APP_BACKEND_URL + "api/v1/";
+}

--- a/src/components/Add.js
+++ b/src/components/Add.js
@@ -22,8 +22,7 @@ export default class Add extends React.Component {
     console.log("Confirmed form: " + JSON.stringify(form_data));
     this.setState({ display: displays.LOADING });
 
-    // Hardcode to localhost:8000 for development mode.
-    fetch("http://localhost:8000/api/v1/coaches", {
+    fetch(cmn.getApiUrlBase() + "coaches", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(form_data),

--- a/src/components/Assign.js
+++ b/src/components/Assign.js
@@ -264,14 +264,7 @@ class AssignForm extends React.Component {
   }
 
   getCoachMatchUrl() {
-    //TODO: Need better URL creation common to all components.
-    var url_base;
-    if (process.env.NODE_ENV !== "production") {
-      url_base = "http://localhost:8000/";
-    } else {
-      url_base = "https://juw492hzej.execute-api.eu-west-2.amazonaws.com/dev/";
-    }
-    var url_fmt = url_base + "api/v1/coach-matches?birth_year={0}&gender={1}&languages={2}&need={3}&rights={4}&housing={5}";
+    var url_fmt = cmn.getApiUrlBase() + "coach-matches?birth_year={0}&gender={1}&languages={2}&need={3}&rights={4}&housing={5}";
 
     var url = this.format(url_fmt,
                           this.state.year,

--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -100,8 +100,7 @@ export default class Edit extends React.Component {
    * @param coachFilter the coach filter
    */
   get_search_url(coachFilter) {
-    // XXX url hardcoded to localhost for development.
-    var url = "http://localhost:8000/api/v1/coaches?";
+    var url = cmn.getApiUrlBase() + "coaches?";
 
     // simple_keys is the list of keys that do not need formatting.
     var simple_keys = ["available", "birth_year", "gender", "name"];
@@ -137,8 +136,7 @@ export default class Edit extends React.Component {
     // Set state to LOADING while getting coach details from server.
     // Set state to EDIT after receiving details.
 
-    // XXX url hardcoded to localhost for development.
-    var url = `http://localhost:8000/api/v1/coaches/${coachID}`;
+    var url = cmn.getApiUrlBase() + `coaches/${coachID}`;
     this.setState({ display: displays.LOADING }, () => {
       fetch(url)
         .then((response) => response.json())
@@ -171,8 +169,7 @@ export default class Edit extends React.Component {
     console.log("Confirmed form: " + JSON.stringify(form_data));
     this.setState({ display: displays.LOADING });
 
-    // XXX url hardcoded to localhost for development.
-    var url = `http://localhost:8000/api/v1/coaches/${form_data["id"]}`;
+    var url = cmn.getApiUrlBase() + `coaches/${form_data["id"]}`;
     fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -191,8 +188,7 @@ export default class Edit extends React.Component {
   handleDeleteConfirm(coachID) {
     console.log("Confirmed delete" + coachID);
 
-    // XXX url hardcoded to localhost for development.
-    var url = `http://localhost:8000/api/v1/coaches/${coachID}`;
+    var url = cmn.getApiUrlBase() + `coaches/${coachID}`;
 
     // Set state to LOADING while getting coach details from server.
     // Set state to TABLE after receiving details.

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -16,6 +16,9 @@
             "provider_arns": [
                 "arn:aws:cognito-idp:eu-west-2:233928554688:userpool/eu-west-2_G4pBFSApd"
             ]
+        },
+        "environment_variables": {
+            "ALLOWED_ORIGINS": "https://sandbox.d1nt2xg69cmmwk.amplifyapp.com/,https://master.d1nt2xg69cmmwk.amplifyapp.com/"
         }
     }
 }

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -1,5 +1,5 @@
 {
-    "dev": {
+    "production": {
         "app_function": "server.app",
         "profile_name": "crisis-deploy",
         "project_name": "crisis",

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -18,7 +18,7 @@
             ]
         },
         "environment_variables": {
-            "ALLOWED_ORIGINS": "https://sandbox.d1nt2xg69cmmwk.amplifyapp.com/,https://master.d1nt2xg69cmmwk.amplifyapp.com/"
+            "ALLOWED_ORIGINS": "https://sandbox.d1nt2xg69cmmwk.amplifyapp.com,https://master.d1nt2xg69cmmwk.amplifyapp.com"
         }
     }
 }


### PR DESCRIPTION
These changes move us closer to supporting multiple instances of the app to be deployed in AWS. Eventually I envisage the following instances.

- `production`: In AWS. Based off the master branch. Right now used by us, but will become the instance used by Crisis staff.
- `staging`: (Does not yet exist.) In AWS. Based off a long-lived branch that we'll presumably call 'staging'. Will be our final test instance before deploying to production.
- `development`: Individual instances running locally on laptops. Not in AWS. Can be based off any public or private branch.

Each AWS instance needs:
- an AWS Amplify frontend for the JS code (taken from a corresponding public branch in the GitHub repo),
- an AWS Cognito user pool against which to authorize,
- an AWS Lambda backend for the server code.

I've created `.env.<instance-name>` files to contain the URL of the backend API for each instance, because yarn/React has native support for these. I've also updated each component to a common API URL constructor that references these environments.

I've specified the frontend URLs allowed to access the backend APIs (the "allowed origins") in Zappa's settings file that defines the backend instances. Eventually I envisage one allowed origin (ie one Amplify frontend instance) per Lambda backend instance, though right now I have an extra, temporary frontend (`sandbox`) that is allowed to access the production backend.